### PR TITLE
Temporary changes made to account for reader updates

### DIFF
--- a/amptools/stream.py
+++ b/amptools/stream.py
@@ -203,11 +203,30 @@ def streams_to_dataframe(streams):
     spectral_streams = []
     for stream in streams:
         for key in meta_dict.keys():
-            if key == 'netid':
-                statskey = 'network'
+            if key == 'name':
+                try:
+                    name_str = stream[0].stats['standard']['station_name']
+                except KeyError:
+                    name_str = stream[0].stats['name']
+                meta_dict[key].append(name_str)
+            elif key == 'lat':
+                try:
+                    latitude = stream[0].stats['coordinates']['latitude']
+                except KeyError:
+                    latitude = stream[0].stats['lat']
+                meta_dict[key].append(latitude)
+            elif key == 'lon':
+                try:
+                    longitude = stream[0].stats['coordinates']['longitude']
+                except KeyError:
+                    longitude = stream[0].stats['lon']
+                meta_dict[key].append(longitude)
             else:
-                statskey = key
-            meta_dict[key].append(stream[0].stats[statskey])
+                if key == 'netid':
+                    statskey = 'network'
+                else:
+                    statskey = key
+                meta_dict[key].append(stream[0].stats[statskey])
         spectral_traces = []
         # process acceleration and store velocity traces
         for idx, trace in enumerate(stream):

--- a/pgm/station_summary.py
+++ b/pgm/station_summary.py
@@ -96,10 +96,22 @@ class StationSummary(object):
             hour = '{:02d}'.format(stats['starttime'].hour)
             minute = '{:02d}'.format(stats['starttime'].minute)
             dataframe_dict['HRMN'] += [hour + minute]
-            dataframe_dict['Station Name'] += [stats['name']]
+            try:
+                station_str = stats['standard']['station_name']
+            except KeyError:
+                station_str = stats['name']
+            dataframe_dict['Station Name'] = [station_str]
             dataframe_dict['Station ID  No.'] += [stats['station']]
-            dataframe_dict['Station Latitude'] += [stats['lat']]
-            dataframe_dict['Station Longitude'] += [stats['lon']]
+            try:
+                latitude = stats['coordinates']['latitude']
+            except KeyError:
+                latitude = stats['lat']
+            dataframe_dict['Station Latitude'] += [latitude]
+            try:
+                longitude = stats['coordinates']['longitude']
+            except KeyError:
+                longitude = stats['lon']
+            dataframe_dict['Station Longitude'] += [longitude]
             dataframe_dict['Channel'] += [imc]
             for imt_key in np.sort(imt_keys):
                 dataframe_dict[imt_key] += [pgms[imt_key][imc]]


### PR DESCRIPTION
`StationSummary` and `streams_to_dataframe` both check two locations for name, lat, and lon. Once reader stats have been updated with the new format, the old stats location option can be removed.
Example:
```
try:
    latitude = stream[0].stats['coordinates']['latitude']
except KeyError:
    # Old stats location. Remove after reader updates.
    latitude = stream[0].stats['lat']
```