### PR TITLE
Bug fixes for install script and knet reader

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include amptools/io/*.csv

--- a/code.json
+++ b/code.json
@@ -27,6 +27,6 @@
     "email": "mhearne@usgs.gov"
   },
   "updated": {
-    "metadataLastUpdated": "2017-09-08"
+    "metadataLastUpdated": "2017-06-25"
   }
 }

--- a/environment.yml
+++ b/environment.yml
@@ -18,5 +18,3 @@ dependencies:
 - openpyxl
 - obspy
 - xlsxwriter
-
-

--- a/install.sh
+++ b/install.sh
@@ -28,7 +28,7 @@ while getopts r FLAG; do
   case $FLAG in
     r)
         reset=1
-        
+
       ;;
   esac
 done
@@ -80,7 +80,11 @@ echo ""
 
 
 # Choose an environment file based on platform
-echo ". $HOME/miniconda/etc/profile.d/conda.sh" >> $prof
+# only add this line if it does not already exist
+grep "/etc/profile.d/conda.sh" $prof
+if [ $? -ne 0 ]; then
+    echo ". $_CONDA_ROOT/etc/profile.d/conda.sh" >> $prof
+fi
 
 # If the user has specified the -r (reset) flag, then create an
 # environment based on only the named dependencies, without

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,10 @@
 from distutils.core import setup
+import glob
 
 setup(name='amptools',
       version='0.1dev',
       description='USGS ShakeMap Strong Motion Data Tools',
+      include_package_data=True,
       author='Mike Hearne',
       author_email='mhearne@usgs.gov',
       url='',
@@ -14,11 +16,16 @@ setup(name='amptools',
                 'amptools.io.cosmos',
                 'amptools.io.smc',
                 'amptools.io.obspy',
+                'amptools.io.usc',
                 'pgm',
                 'pgm.imt',
                 'pgm.imc'],
+      package_data={
+          'amptools': glob.glob('amptools/io/*.csv') + glob.glob('tests/data/*/*'),
+          'pgm': glob.glob('amptools/io/*.csv') + glob.glob('tests/data/*/*')
+      },
       scripts=['bin/amps2xml',
                'bin/ftpfetch',
                'bin/sm2xml',
-               'bin/getpgm'],
+               'bin/getpgm']
       )

--- a/tests/bin/sm2xml_test.py
+++ b/tests/bin/sm2xml_test.py
@@ -64,7 +64,7 @@ def test_sm2xml():
     target_source = 'Japan National Research Institute for Earth Science and Disaster Resilience'
     for idx in range(3, len(columns['Unnamed: 2'])):
         assert columns['Unnamed: 2'][idx] == target_source
-    target_network = 'KNET'
+    target_network = 'BO'
     for idx in range(3, len(columns['Unnamed: 3'])):
         assert columns['Unnamed: 3'][idx] == target_network
     target_latitudes = np.asarray([41.5267, 41.328, 41.4053, 41.4087, 41.2948,


### PR DESCRIPTION
Fixes include:
- start using _CONDA_ROOT environment variable
- check that commands do not already exist before adding
- add MANIFEST.IN and package_data to include data in conda package
- set calib to the knet scaling factor
- account for knet sensor 15 second delay
- fix network code

The changes to setup.py and the addition of MANIFEST.in should include important data (fdsn_codes.csv) in the conda package. This will be tested once merged and bug fix version update occurs.