### PR TITLE
Add processing from a config file

### DIFF
--- a/amptools/config.py
+++ b/amptools/config.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python
+
+# stdlib imports
+import copy
+import os.path
+
+# third party imports
+import yaml
+
+# local imports
+from amptools.constants import CONFIG_FILE, DEFAULT_CONFIG
+
+
+def get_config():
+    """Gets the user defined config and validates it.
+
+    Notes:
+        If no config file is present, default parameters are used.
+
+    Returns:
+        dictionary: Configuration parameters.
+    """
+    config_file = os.path.join(os.path.expanduser('~'), CONFIG_FILE)
+    if not os.path.isfile(config_file):
+        config = DEFAULT_CONFIG
+        fmt = 'Missing config file %s, setting config to default config.'
+        print(fmt % config_file)
+    else:
+        config = yaml.safe_load(open(config_file, 'rt'))
+        _validate_config(config)
+    return config
+
+def _validate_config(config):
+    """Helper to validate user defined config.
+
+    Args:
+        config(dictionary): Dictionary of config.
+
+    Raises:
+        TypeError if config is not a dictionary.
+        KeyError if a required parameter is not included.
+    """
+    if not isinstance(config, dict):
+        raise TypeError("Config is empty or is populated incorrectly.")
+    config_keys = _get_keys(copy.deepcopy(config), [])
+    default_keys = _get_keys(copy.deepcopy(DEFAULT_CONFIG), [])
+    difference = [key for key in default_keys if key not in config_keys]
+    if len(difference) > 0:
+        raise KeyError('Missing required parameters %r.' % difference)
+
+def _get_keys(config_dict, keys):
+    """Helper to get a list of all keys in the dictionary.
+
+    Args:
+        config_dict (dictionary): Dictionary of config.
+        keys (list): list of keys (str).
+
+    Returns:
+        list: list of keys (str).
+    """
+    for k, v in config_dict.items():
+        if isinstance(v, dict):
+            _get_keys(v, keys=keys)
+        else:
+            keys += [k]
+    return keys

--- a/amptools/constants.py
+++ b/amptools/constants.py
@@ -1,0 +1,37 @@
+CONFIG_FILE = '.amptools/config.yml'
+
+DEFAULT_CONFIG = {
+        'processing_parameters': {
+                'amplitude': {
+                        'min': 10e-9,
+                        'max': 50.0
+                },
+                'window': {
+                        'vmin': 1.0
+                },
+                'taper': {
+                        'type': 'hann',
+                        'max_percentage': 0.05,
+                        'side': 'both'
+                },
+                'corners': {
+                        'get_dynamically': True,
+                        'sn_ratio': 3.0,
+                        'default_low_frequency': 0.1,
+                        'default_high_frequency': 20.0
+                },
+                'filters': [{
+                        'type': 'highpass',
+                        'corners': 4,
+                        'zerophase': True
+                },{
+                        'type': 'lowpass',
+                        'corners': 4,
+                        'zerophase': True
+                }],
+                'baseline_correct': True,
+        },
+        'sm2xml': {
+                'imtlist': ['PGA', 'PGV', 'SA(0.3)', 'SA(1.0)', 'SA(3.0)']
+        }
+}

--- a/amptools/stream.py
+++ b/amptools/stream.py
@@ -282,6 +282,7 @@ def streams_to_dataframe(streams, lat=None, lon=None, imtlist=None):
             if units == 'acc':
                 # do some basic data processing - if this has already been
                 # done, it shouldn't hurt to repeat it.
+                #TODO Check if data was processed/use new process routine
                 with warnings.catch_warnings():
                     warnings.simplefilter("ignore")
                     stream[idx] = filter_detrend(trace, taper_type='cosine',

--- a/bin/sm2xml
+++ b/bin/sm2xml
@@ -16,24 +16,12 @@ import yaml
 
 # local imports
 from amptools.table import dataframe_to_xml
-from amptools.stream import streams_to_dataframe, group_channels, DEFAULT_IMTS
+from amptools.stream import streams_to_dataframe, group_channels
 from amptools.io.read import read_data, _get_format
+from amptools.config import get_config
 
 FORMATS = ['cwb', 'geonet', 'knet', 'cosmos', 'smc', 'dmg', 'obspy']
 DEFAULT_DISTANCE = 1500
-
-CONFIG_FILE = '.amptools/config.yml'
-
-
-def get_config():
-    config_file = os.path.join(os.path.expanduser('~'), CONFIG_FILE)
-    if not os.path.isfile(config_file):
-        config = {'sm2xml': {'imtlist': DEFAULT_IMTS}}
-        fmt = 'Missing config file %s, setting IMT list to %s.'
-        print(fmt % (config_file, DEFAULT_IMTS))
-    else:
-        config = yaml.load(open(config_file, 'rt'))
-    return config
 
 
 def _clean_sheet(outfile_excel, dataframe):
@@ -114,7 +102,6 @@ def main(args):
     indir = args.indir
     eventid = args.eventid
     outdir = args.outdir
-
     config = get_config()
 
     # make the output directory if it does not exist

--- a/tests/amptools/process_test.py
+++ b/tests/amptools/process_test.py
@@ -54,11 +54,47 @@ def test_corner_freqs():
 
 
 def test_all():
+    config = {
+    'processing_parameters': {
+            'amplitude': {
+                    'min': 10e-9,
+                    'max': 50.0
+            },
+            'window': {
+                    'vmin': 1.0
+            },
+            'taper': {
+                    'type': 'hann',
+                    'max_percentage': 0.05,
+                    'side': 'both'
+            },
+            'corners': {
+                    'get_dynamically': True,
+                    'sn_ratio': 3.0,
+                    'default_low_frequency': 0.1,
+                    'default_high_frequency': 20.0
+            },
+            'filters': [{
+                    'type': 'highpass',
+                    'corners': 4,
+                    'zerophase': True
+            },{
+                    'type': 'lowpass',
+                    'corners': 4,
+                    'zerophase': True
+            }],
+            'baseline_correct': True,
+    },
+    'sm2xml': {
+            'imtlist': ['PGA', 'PGV', 'SA(0.3)', 'SA(1.0)', 'SA(3.0)']
+    }
+    }
     # Get our data directory
     event_time = UTCDateTime('2003-01-15T03:41:58')
     HAWA_dist = 80.1893
     HAWA_tr = read(os.path.join(datadir, 'HAWABHN.US..sac'))[0]
-    HAWA_processed = process.process_all(HAWA_tr, event_time, HAWA_dist)
+    HAWA_processed = process.process_config([HAWA_tr], config=config,
+            event_time=event_time, epi_dist=HAWA_dist)[0]
     # Load in the already calculated array form processing
     HAWA_array = np.genfromtxt(os.path.join(datadir,
                                             'HAWABHN.US..sac.acc.final.txt'),
@@ -73,37 +109,98 @@ def test_all():
     event_time = UTCDateTime('2001-02-28T18:54:32')
     BRI_dist = 55.6385
     BRI_tr = read(os.path.join(datadir, 'BRIHN1.GS..sac'))[0]
-    process.process_all(BRI_tr, event_time, BRI_dist)
+    BRI_processed = process.process_config([BRI_tr], config=config,
+            event_time=event_time, epi_dist=BRI_dist)[0]
+    assert BRI_processed.stats['passed_tests'] == True
 
     # Triggers the invalid low pass filtering warning
     event_time = UTCDateTime('2001-02-28T18:54:32')
     ALCT_dist = 75.9559
     ALCT_tr = read(os.path.join(datadir, 'ALCTENE.UW..sac'))[0]
-    process.process_all(ALCT_tr, event_time, ALCT_dist)
+    ALCT_processed = process.process_config([ALCT_tr], config=config,
+            event_time=event_time, epi_dist=ALCT_dist)[0]
+    assert ALCT_processed.stats['passed_tests'] == True
 
     GNW_tr = read(os.path.join(datadir, 'GNWBHE.UW..sac'))[0]
     GNW_dist = 46.7473
-    process.process_all(GNW_tr, event_time, GNW_dist)
+    GNW_processed = process.process_config([GNW_tr], config=config,
+            event_time=event_time, epi_dist=GNW_dist)[0]
+    assert GNW_processed.stats['passed_tests'] == True
+
 
     # Test trace with invalid amplitudes
     NOWS_tr_mul = read(os.path.join(datadir, 'NOWSENR_mul.sac'))[0]
     time = UTCDateTime('2001-02-14T22:03:58')
     dist = 50.05
-    assert process.process_all(NOWS_tr_mul, time, dist) is None
+    NOWS_processed = process.process_config([NOWS_tr_mul], config=config,
+            event_time=time, epi_dist=dist)[0]
+    assert NOWS_processed.stats['passed_tests'] == False
 
     # Test trace with low S/N ratio
     event_time = UTCDateTime('2016-10-22T17:17:05')
     ALKI_tr = read(os.path.join(datadir, 'ALKIENE.UW..sac'))[0]
     ALKI_dist = 37.87883
-    ALKI_processed = process.process_all(ALKI_tr, event_time, ALKI_dist)
-    assert ALKI_processed is None
+    ALKI_processed = process.process_config([ALKI_tr], config=config,
+            event_time=event_time, epi_dist=ALKI_dist)[0]
+    assert ALKI_processed.stats.processing_parameters.corners['default_low_frequency'] == 0.1
+    assert ALKI_processed.stats.processing_parameters.corners['default_high_frequency'] == 20.0
 
     # Test with invalid starttime
     ALKI_tr.stats.starttime += 500
-    assert process.process_all(ALKI_tr, event_time, ALKI_dist) is None
+    ALKI_processed = process.process_config([ALKI_tr], config=config,
+            event_time=event_time, epi_dist=ALKI_dist)[0]
+    assert ALKI_processed.stats['passed_tests'] == False
 
     ALKI_split = process.split_signal_and_noise(ALKI_tr, event_time, ALKI_dist)
     assert ALKI_split == (-1, -1)
+
+    config = {
+        'processing_parameters': {
+                'amplitude': {
+                        'min': 10e-9,
+                        'max': 50.0
+                },
+                'window': {
+                        'vmin': 1.0
+                },
+                'taper': {
+                        'type': 'hann',
+                        'max_percentage': 0.05,
+                        'side': 'both'
+                },
+                'corners': {
+                        'get_dynamically': False,
+                        'sn_ratio': 3.0,
+                        'default_low_frequency': 0.1,
+                        'default_high_frequency': 20.0
+                },
+                'filters': [{
+                        'type': 'highpass',
+                        'corners': 4,
+                        'zerophase': True
+                },{
+                        'type': 'lowpass',
+                        'corners': 4,
+                        'zerophase': True
+                },{
+                        'type': 'bandpass',
+                        'corners': 4,
+                        'zerophase': True
+                },{
+                        'type': 'invalid',
+                        'corners': 4,
+                        'zerophase': True
+                }],
+                'baseline_correct': False,
+        },
+        'sm2xml': {
+                'imtlist': ['PGA', 'PGV', 'SA(0.3)', 'SA(1.0)', 'SA(3.0)']
+        }
+    }
+    ALKI_processed = process.process_config([ALKI_tr], config=config)[0]
+    assert ALKI_processed.stats['passed_tests'] == False
+    ALKI_processed = process.process_config([ALKI_tr])[0]
+    assert ALKI_processed.stats['passed_tests'] == False
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Created a generic `process` method that performs steps [4-11](https://doi.org/10.1193/101916EQS175DP). This requires all parameters. In order to perform processing with defaults use `process_config`. This will either use a config located in ~/.amptools/config.yml or the default contained in  constants.py. All keys in the default config are required in any other config supplied. 

Processing can be done with or without event information. However, processing without event time or epicentral distance will be marked as failing tests, since windowing cannot be performed. Getting corner dynamically cannot be performed without windowing.

Closes #77 
Closes #78