### PR TITLE
Adjustment of algorithm for dynamically finding low corner frequency.

### DIFF
--- a/amptools/process.py
+++ b/amptools/process.py
@@ -259,19 +259,24 @@ def get_corner_frequencies(trace, event_time, epi_dist, ratio=3.0):
 
         # loop through each frequency and calculate the signal to noise ratio
         # If S/N greater than ratio, found a corner frequency
-        # Loop once for finding low corner...
-        corner_frequencies = []
-        for i, freq in enumerate(freqs_signal):
-            if (sig_spec_smooth[i] / noise_spec_smooth[i] >= ratio):
-                corner_frequencies.append(freq)
-                break
 
-        # ...And once for finding high corner
+        corner_frequencies = []
+        found_high = False
         for i, freq in enumerate(freqs_noise):
             idx = len(freqs_signal)-i-1  # Looping backwards through freqs
-            if (sig_spec_smooth[idx] / noise_spec_smooth[idx] >= ratio):
-                corner_frequencies.append(freqs_signal[idx])
-                break
+            if found_high is False:
+                if (sig_spec_smooth[idx] / noise_spec_smooth[idx] >= ratio):
+                    corner_frequencies.append(freqs_signal[idx])
+                    found_high = True
+                else:
+                    continue
+            else:
+                if (sig_spec_smooth[idx] / noise_spec_smooth[idx] < ratio):
+                    corner_frequencies.append(freqs_signal[idx])
+                    break
+                else:
+                    continue
+
         # if we reached the end without finding two corner frequencies
         # inadequate S/N
         if len(corner_frequencies) != 2:
@@ -530,8 +535,8 @@ def process(stream, amp_min, amp_max, window_vmin, taper_type,
                 low_freq = default_low_frequency
                 dynamic = False
             else:
-                low_freq = corners[0]
-                high_freq = corners[1]
+                high_freq = corners[0]
+                low_freq = corners[1]
                 dynamic = True
         else:
             high_freq = default_high_frequency

--- a/amptools/process.py
+++ b/amptools/process.py
@@ -92,7 +92,7 @@ def remove_clipped(stream, max_count=2000000):
     return stream
 
 
-def check_max_amplitude(trace, min_amp=10e-9, max_amp=50):
+def check_max_amplitude(trace, min_amp=10e-7, max_amp=5e3):
         """
         Checks that the maximum amplitude of the trace is within a defined
         range.

--- a/tests/amptools/process_test.py
+++ b/tests/amptools/process_test.py
@@ -7,6 +7,7 @@ import numpy as np
 # third party imports
 from obspy.core.stream import read
 from obspy.core.utcdatetime import UTCDateTime
+from obspy import Trace
 from amptools import process
 
 homedir = os.path.dirname(os.path.abspath(__file__))
@@ -19,7 +20,7 @@ def test_amp_check_trim():
     # one is unedited with a standard maximum amplitude
     # the second has been multiplied so that it fails the amplitude check
     NOWS_tr = read(os.path.join(datadir, 'NOWSENR.sac'))[0]
-    NOWS_tr_mul = read(os.path.join(datadir, 'NOWSENR_mul.sac'))[0]
+    NOWS_tr_mul = Trace(data=NOWS_tr.data*10e9, header=NOWS_tr.stats)
 
     assert process.check_max_amplitude(NOWS_tr) is True
     assert process.check_max_amplitude(NOWS_tr_mul) is False

--- a/tests/amptools/process_test.py
+++ b/tests/amptools/process_test.py
@@ -40,10 +40,10 @@ def test_corner_freqs():
     GNW_dist = 46.7473
 
     corners_1 = process.get_corner_frequencies(ALCT_tr, event_time, ALCT_dist)
-    np.testing.assert_allclose(corners_1, [0.03662, 50.0], atol=0.001)
+    np.testing.assert_allclose(corners_1, [50.0, 0.030], atol=0.001)
 
     corners_2 = process.get_corner_frequencies(GNW_tr, event_time, GNW_dist)
-    np.testing.assert_allclose(corners_2, [0.03662, 25.0], atol=0.001)
+    np.testing.assert_allclose(corners_2, [25.0, 0.030], atol=0.001)
 
     event_time = UTCDateTime('2016-10-22T17:17:05')
     ALKI_tr = read(os.path.join(datadir, 'ALKIENE.UW..sac'))[0]


### PR DESCRIPTION
This improves the algorithm for finding a trace's low-pass filter frequency. Before, the algorithm would loop starting from the smallest frequency and continue until the S/N ratio reaches a minimum value. This algorithm doesn't always pick the best frequency, as the signal and noise curves can cross-over multiple times, especially at low frequencies.

Instead, the new algorithm starts the loop at the highest frequency and works downward. The following image shows the different picks for low corner frequency.

![corners](https://user-images.githubusercontent.com/40367182/43086022-a1197256-8e59-11e8-98d5-ea2206954772.png)
